### PR TITLE
Additional logstash examples

### DIFF
--- a/windows-unc.conf
+++ b/windows-unc.conf
@@ -1,0 +1,30 @@
+input {
+    file {
+      # The UNC path needs to be mounted as a drive letter for logstash to pick it up, hence the Z: drive below
+      path => "Z:/test.log"
+      start_position => "beginning"
+      add_field => {
+        "LogType" => "unc-log"
+        "Source" => "mounted-unc-path"
+      }
+    }
+    # When using logstash on a Windows machine it's best to use winlogbeats to ingest event logs. 
+    # See the winlogbeats.yml in this repo for that config.
+    beats {
+      port => 5044
+    }
+}
+
+filter {
+      mutate {
+        add_field => {
+          "hostname" => "%{host}"
+        }
+      }
+    }
+
+output {
+  newrelic {
+    license_key => "NR License Key"
+  }
+}

--- a/winlogbeats.yml
+++ b/winlogbeats.yml
@@ -1,0 +1,99 @@
+# ======================== Winlogbeat specific options =========================
+
+# event_logs specifies a list of event logs to monitor as well as any
+# accompanying options. The YAML data type of event_logs is a list of
+# dictionaries.
+#
+# The supported keys are name (required), tags, fields, fields_under_root,
+# forwarded, ignore_older, level, event_id, provider, and include_xml. Please
+# visit the documentation for the complete details of each option.
+# https://go.es.io/WinlogbeatConfig
+
+winlogbeat.event_logs:
+  - name: Application
+    ignore_older: 72h
+
+  - name: System
+    ignore_older: 72h
+
+  # Security Event Logs. Explicit Event IDs are collected as well as ranges. Event IDs prefixed by - are excluded.
+  - name: Security
+    ignore_older: 72h
+    event_id: 4624, 4625, 4700-4800, -4735
+
+  # Powershell Event Logs
+  - name: Windows Powershell
+    ignore_older: 72h
+  
+  # SCOM Event Logs
+  - name: Operations Manager
+    ignore_older: 72h
+  
+  # Windows Failover Clustering Event Logs
+  - name: Microsoft-Windows-FailoverClustering/Operational
+    ignore_older: 72h
+
+# ================================== General ===================================
+
+# The name of the shipper that publishes the network data. It can be used to group
+# all the transactions sent by a single shipper in the web interface.
+#name:
+
+# The tags of the shipper are included in their own field with each
+# transaction published.
+#tags: ["service-X", "web-tier"]
+
+# Optional fields that you can specify to add additional information to the
+# output.
+#fields:
+#  env: staging
+
+# ------------------------------ Logstash Output -------------------------------
+output.logstash:
+  # The Logstash hosts
+  hosts: ["localhost:5044"]
+  # pipelining: 0
+
+  # Optional SSL. By default is off.
+  # List of root certificates for HTTPS server verifications
+  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+  # Certificate for SSL client authentication
+  #ssl.certificate: "/etc/pki/client/cert.pem"
+
+  # Client Certificate Key
+  #ssl.key: "/etc/pki/client/cert.key"
+
+# ================================= Processors =================================
+processors:
+  - add_host_metadata:
+      when.not.contains.tags: forwarded
+  - add_cloud_metadata: ~
+
+# ================================== Logging ===================================
+
+# Sets log level. The default log level is info.
+# Available log levels are: error, warning, info, debug
+#logging.level: debug
+
+# At debug level, you can selectively enable logging only for some components.
+# To enable all selectors use ["*"]. Examples of other selectors are "beat",
+# "publisher", "service".
+#logging.selectors: ["*"]
+
+
+# ============================== Instrumentation ===============================
+
+# Instrumentation support for the winlogbeat.
+#instrumentation:
+    # Set to true to enable instrumentation of winlogbeat.
+    #enabled: false
+
+    # Environment in which winlogbeat is running on (eg: staging, production, etc.)
+    #environment: ""
+
+# ================================= Migration ==================================
+
+# This allows to enable 6.7 migration aliases
+#migration.6_to_7.enabled: true
+


### PR DESCRIPTION
These examples cover two different use cases, but can also be used together. the winlogbeats.yml file shows how to ingest event logs on a windows machine while the unc.conf file shows how we can ingest logs from a windows unc path if it's mounted as a drive letter.